### PR TITLE
Typo Correction in Comment

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@
  */
 export interface EventSourceParser {
   /**
-   * Feeds the parser another another chunk. The method _does not_ return a parsed message.
+   * Feeds the parser another chunk. The method _does not_ return a parsed message.
    * Instead, if the chunk was a complete message (or completed a previously incomplete message),
    * it will invoke the `onParse` callback used to create the parsers.
    *


### PR DESCRIPTION
## Description
This pull request corrects a minor typographical error in the `EventSourceParser` interface comments where the word "another" was duplicated. This change is purely cosmetic and does not affect functionality.