### PR TITLE
docs: fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import {createParser, type EventSourceMessage} from 'eventsource-parser'
 function onEvent(event: EventSourceMessage) {
   console.log('Received event!')
   console.log('id: %s', event.id || '<none>')
-  console.log('name: %s', event.name || '<none>')
+  console.log('event: %s', event.event || '<none>')
   console.log('data: %s', event.data)
 }
 


### PR DESCRIPTION
fix the code example

Property 'name' does not exist on type 'EventSourceMessage'.

```
EventSourceMessage: {
  event?: string
  id?: string
  data: string
}
```