### PR TITLE
Update reference to old onParse method

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface EventSourceParser {
   /**
    * Feeds the parser another chunk. The method _does not_ return a parsed message.
    * Instead, if the chunk was a complete message (or completed a previously incomplete message),
-   * it will invoke the `onParse` callback used to create the parsers.
+   * it will invoke the `onEvent` callback used to create the parser.
    *
    * @param chunk - The chunk to parse. Can be a partial, eg in the case of streaming messages.
    * @public


### PR DESCRIPTION
I'm not totally sure if this change is correct, but I just stumbled on a jsdoc that mentions onParse, and it seems like that is from an older version of this library. 

There are a couple other references to onParse around the repo, can update those if this makes sense.