### PR TITLE
perf: avoid O(N²) when a single SSE event spans many chunks

### DIFF
--- a/bench/parse.bench.ts
+++ b/bench/parse.bench.ts
@@ -25,8 +25,10 @@ import {
   createDataOnlyFixture,
   createEdgeCasesFixture,
   createHeartbeatFixture,
+  createHugeLineDripFixture,
   createIdentifiedEventFixture,
   createIdleStreamFixture,
+  createLargeMultilineDataFixture,
   createMultibyteFixture,
   createNamedEventFixture,
   createSmallChunkFixture,
@@ -53,7 +55,13 @@ const FIXTURES = {
   multibyte: materialize(createMultibyteFixture({count: 128})),
   heartbeat: materialize(createHeartbeatFixture({count: 64})),
   'idle-stream': materialize(createIdleStreamFixture({count: 512})),
+  'huge-line-drip': materialize(
+    createHugeLineDripFixture({payloadSize: 256 * 1024, avgChunkSize: 4}),
+  ),
   'small-chunk': materialize(createSmallChunkFixture({count: 128, avgChunkSize: 8})),
+  'large-multiline-data': materialize(
+    createLargeMultilineDataFixture({linesPerEvent: 500, lineLength: 80}),
+  ),
   'edge-cases': materialize(createEdgeCasesFixture()),
 } as const satisfies Record<string, Fixture>
 
@@ -66,7 +74,9 @@ const CASES: CaseName[] = [
   'multibyte',
   'heartbeat',
   'idle-stream',
+  'huge-line-drip',
   'small-chunk',
+  'large-multiline-data',
   'edge-cases',
 ]
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -36,7 +36,13 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
 
   const {onEvent = noop, onError = noop, onRetry = noop, onComment} = callbacks
 
-  let incompleteLine = ''
+  // Trailing bytes from prior `feed()` calls that did not yet form a complete line.
+  // Stored as an array of fragments and only joined when a line terminator arrives.
+  // Concatenating per-feed (`prefix + chunk`) is O(N²) when a single SSE line spans
+  // many chunks (e.g. a large `data:` payload streamed in tiny slices, or an MCP-style
+  // server that emits one giant content block). Buffering as fragments + joining once
+  // makes the same workload linear.
+  const pendingFragments: string[] = []
 
   let isFirstChunk = true
   let id: string | undefined
@@ -50,36 +56,47 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
    * so callers can pass arbitrary slices of the stream without worrying about
    * line boundaries.
    *
-   * The first chunk is dispatched to {@link feedFirst} so the leading UTF-8
-   * BOM can be stripped before parsing begins.
+   * Per the SSE spec, a UTF-8 BOM (0xEF 0xBB 0xBF) at the start of the very
+   * first chunk is stripped before parsing.
+   *
+   * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
    */
   function feed(chunk: string) {
     if (isFirstChunk) {
       isFirstChunk = false
-      feedFirst(chunk)
+      if (
+        chunk.charCodeAt(0) === 0xef &&
+        chunk.charCodeAt(1) === 0xbb &&
+        chunk.charCodeAt(2) === 0xbf
+      ) {
+        chunk = chunk.slice(3)
+      }
+    }
+
+    // Hot path: no buffered prefix from a prior partial line. Hand the chunk
+    // straight to `processLines`, exactly like the original implementation.
+    // Zero new work in the common case (every chunk ends with `\n\n`).
+    if (pendingFragments.length === 0) {
+      const trailing = processLines(chunk)
+      if (trailing !== '') pendingFragments.push(trailing)
       return
     }
-    const input = incompleteLine === '' ? chunk : incompleteLine + chunk
-    incompleteLine = processLines(input)
-  }
 
-  /**
-   * Handles the very first chunk of the stream. Per the SSE spec, a UTF-8 BOM
-   * (0xEF 0xBB 0xBF) at the start of the stream must be stripped before
-   * parsing. After BOM handling, behaves identically to {@link feed}.
-   *
-   * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
-   */
-  function feedFirst(chunk: string) {
-    if (
-      chunk.charCodeAt(0) === 0xef &&
-      chunk.charCodeAt(1) === 0xbb &&
-      chunk.charCodeAt(2) === 0xbf
-    ) {
-      chunk = chunk.slice(3)
+    // We have a buffered prefix. If this chunk also has no terminator, append
+    // to the buffer without concatenating — that's the O(N²) trap we're
+    // avoiding (large single `data:` payload split across many tiny chunks).
+    if (chunk.indexOf('\n') === -1 && chunk.indexOf('\r') === -1) {
+      pendingFragments.push(chunk)
+      return
     }
-    const input = incompleteLine === '' ? chunk : incompleteLine + chunk
-    incompleteLine = processLines(input)
+
+    // Terminator arrived. Join the accumulated fragments + this chunk once,
+    // process, and buffer any new trailing partial line.
+    pendingFragments.push(chunk)
+    const input = pendingFragments.join('')
+    pendingFragments.length = 0
+    const trailing = processLines(input)
+    if (trailing !== '') pendingFragments.push(trailing)
   }
 
   /**
@@ -320,7 +337,8 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
   }
 
   function reset(options: {consume?: boolean} = {}) {
-    if (incompleteLine && options.consume) {
+    if (options.consume && pendingFragments.length > 0) {
+      const incompleteLine = pendingFragments.join('')
       parseLine(incompleteLine, 0, incompleteLine.length)
     }
 
@@ -329,7 +347,7 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
     data = ''
     dataLines = 0
     eventType = undefined
-    incompleteLine = ''
+    pendingFragments.length = 0
   }
 
   return {feed, reset}

--- a/test/benchmark-fixtures.ts
+++ b/test/benchmark-fixtures.ts
@@ -27,6 +27,11 @@ import {MULTIBYTE_EMOJIS, MULTIBYTE_LINES} from './multibyte.ts'
  *     open — no newlines until a real event eventually arrives. Exercises the
  *     incomplete-line buffer under worst-case growth (each feed rescans the full buffer
  *     for `\r`/`\n`).
+ *   - huge-line-drip: a single large `data:` payload streamed in tiny variable-size chunks
+ *     with no terminator until the very end. Direct probe for the per-feed `prefix + chunk`
+ *     concatenation pattern, which is O(N²) in total bytes when the line spans many chunks.
+ *   - large-multiline-data: a single event built from many `data:` continuation lines.
+ *     Exercises the multi-line `data:` accumulator at scale.
  *   - edge-cases: a mix that falls off the fast path (CRLF, comments, multi-line data,
  *     unknown fields, split CRLF pairs).
  */
@@ -279,6 +284,47 @@ export function createIdleStreamFixture(options: FixtureOptions = {}): Benchmark
   }
 }
 
+export interface HugeLineDripOptions extends FixtureOptions {
+  /** Total payload size, in characters. Defaults to 256 KiB. */
+  payloadSize?: number
+  /** Average chunk size, in characters. Defaults to 4. */
+  avgChunkSize?: number
+}
+
+/**
+ * A single large `data:` line dripped to `feed()` in tiny, variable-size chunks.
+ *
+ * No newline arrives until the entire payload has been streamed in. Parsers that buffer
+ * the incomplete line by repeatedly running `incompleteLine = incompleteLine + chunk` are
+ * O(N·K) — N bytes spread across K chunks — because every feed copies the full accumulated
+ * prefix. Realistic shape of a long LLM response delivered with no intra-event newlines,
+ * or an MCP-style server that emits the full response as a single content block.
+ *
+ * Distinct from `idle-stream`, which exercises the comment-line buffering path; this
+ * fixture exercises the `data:` field path with the same buffering pathology.
+ */
+export function createHugeLineDripFixture(options: HugeLineDripOptions = {}): BenchmarkFixture {
+  const rng = makeRng(options.seed)
+  const payloadSize = options.payloadSize ?? 256 * 1024
+  const avg = options.avgChunkSize ?? 4
+
+  const payload = randomId(rng, payloadSize)
+  const full = `data: ${payload}\n\n`
+
+  const chunks: string[] = []
+  let pos = 0
+  while (pos < full.length) {
+    const size = 1 + Math.floor(rng() * (avg * 2 - 1))
+    chunks.push(full.slice(pos, pos + size))
+    pos += size
+  }
+
+  return {
+    chunks,
+    events: [{id: undefined, event: undefined, data: payload}],
+  }
+}
+
 /**
  * A stream sliced into many small, variable-size chunks.
  *
@@ -304,6 +350,45 @@ export function createSmallChunkFixture(options: SmallChunkOptions = {}): Benchm
   }
 
   return {chunks, events}
+}
+
+export interface LargeMultilineDataOptions extends FixtureOptions {
+  /** Number of `data:` continuation lines per event. Defaults to 500. */
+  linesPerEvent?: number
+  /** Approximate length of each `data:` line value, in characters. Defaults to 80. */
+  lineLength?: number
+}
+
+/**
+ * A single event built from many `data:` continuation lines.
+ *
+ * Per spec, multiple `data:` lines within one event are joined by `\n` into a single
+ * payload. Exercises the multi-line `data:` accumulator at scale (M lines, each L chars,
+ * dispatched as one event). Useful as a regression case when changing how `data:` lines
+ * are accumulated; the build-up cost is itself sensitive to whether the engine can
+ * represent the running concatenation lazily (V8 ConsString) versus eagerly flattening.
+ */
+export function createLargeMultilineDataFixture(
+  options: LargeMultilineDataOptions = {},
+): BenchmarkFixture {
+  const rng = makeRng(options.seed)
+  const lines = options.linesPerEvent ?? 500
+  const lineLength = options.lineLength ?? 80
+
+  const dataPrefix = 'data: '
+  const dataLines: string[] = []
+  const valueLines: string[] = []
+  for (let i = 0; i < lines; i++) {
+    const value = randomId(rng, lineLength)
+    valueLines.push(value)
+    dataLines.push(`${dataPrefix}${value}\n`)
+  }
+  const chunk = `${dataLines.join('')}\n`
+
+  return {
+    chunks: [chunk],
+    events: [{id: undefined, event: undefined, data: valueLines.join('\n')}],
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`createParser().feed(chunk)` is O(N²) in total bytes when a single SSE line spans many chunks. The cost is `incompleteLine = incompleteLine + chunk`, which allocates a new string sized at all-bytes-seen-so-far on every call.

This swaps the string accumulator for `pendingFragments: string[]`, joined exactly once when a line terminator finally arrives. The hot path is gated by a single `pendingFragments.length === 0` check and delegates straight to `processLines(chunk)` exactly like the original.

End-to-end win on a real MCP workload: **93 s → 6.8 s** parsing a 280 MB payload (≈14×). Synthetic bench: ~640× on the worst-case shape.

## Background

Prior work addressed *intra-chunk* line splitting: [#19](https://github.com/rexxars/eventsource-parser/issues/19) closed by 3.0.1's `splitLines` rewrite ([`8952917`](https://github.com/rexxars/eventsource-parser/commit/8952917)), and [vercel/ai#5862](https://github.com/vercel/ai/pull/5862) closed after 3.0.1.

Neither touched the per-feed concat. It only really hurts when a single SSE event carries a large payload streamed in many small chunks. That shape shows up with LLM responses without intra-event newlines, MCP-over-SSE servers like `mcp-clickhouse` that emit results as one content block, or any consumer chunking on small TCP/TLS frames. 3.0.7's perf refactor improved per-line work but left the concatenation pattern intact.

## The bug

`src/parse.ts` (3.0.7):

```ts
let incompleteLine = ''

function feed(chunk: string) {
  // ...
  const input = incompleteLine === '' ? chunk : incompleteLine + chunk
  incompleteLine = processLines(input)
}
```

For a stream where one SSE line is N bytes split across K chunks (no terminator until the very end), every `feed()` allocates a string sized at the running total. Total work is `Σ(i × chunk_size)` ≈ `O(N²/chunk_size)`.

## Reproducing

The new `huge-line-drip` bench fixture (256 KiB payload chunked into 1–8 byte slices, no terminator until the end) on `main`:

```
feed() — huge-line-drip   1300.00 ms/iter   (~30 MB allocated)
```

Per-chunk cost grows linearly with the buffer already accumulated. Classic "string concat in a loop" fingerprint. Measured against a real 280 MB MCP payload:

| Buffered so far | Per-chunk processing |
| --------------: | -------------------: |
|            3 MB |                 1 ms |
|           66 MB |                 8 ms |
|          131 MB |                16 ms |
|          197 MB |                27 ms |
|          262 MB |                37 ms |
|          288 MB |                79 ms |

For a real-world reproducer: point `@ai-sdk/mcp` at `mcp-clickhouse` against any ClickHouse instance with a ≥1M-row table, issue `SELECT * LIMIT 1000000`. `mcp-clickhouse` builds the full result string and emits it as a single SSE `message` event.

## The fix

```ts
// Hot path: no buffered prefix from a prior partial line. Hand the chunk
// straight to processLines, exactly like the original implementation.
// Zero new work in the common case (every chunk ends with `\n\n`).
if (pendingFragments.length === 0) {
  const trailing = processLines(chunk)
  if (trailing !== '') pendingFragments.push(trailing)
  return
}

// We have a buffered prefix. If this chunk also has no terminator, append
// to the buffer without concatenating. That's the O(N²) trap we're avoiding.
if (chunk.indexOf('\n') === -1 && chunk.indexOf('\r') === -1) {
  pendingFragments.push(chunk)
  return
}

// Terminator arrived. Join the accumulated fragments + this chunk once,
// process, and buffer any new trailing partial line.
pendingFragments.push(chunk)
const input = pendingFragments.join('')
pendingFragments.length = 0
const trailing = processLines(input)
if (trailing !== '') pendingFragments.push(trailing)
```

`processLines` and `parseLine` internals are unchanged. `reset()` adapts to the array form. `feedFirst` is inlined into `feed` (one BOM check on the first chunk, gated by the existing `isFirstChunk` flag).

**Why the hot path stays free:** well-formed SSE chunks end with `\n\n`. `processLines` consumes them, returns `''`, and nothing gets pushed. The next call sees `pendingFragments.length === 0` and takes the same path the original code did. The buffering only kicks in once a chunk leaves a partial line behind.

## Validation

### Synthetic bench

Matched-clock comparison (Apple M4 Max, Node 24.11, mitata defaults):

| Bench                |   Baseline |         Fix |         Δ |
| -------------------- | ---------: | ----------: | --------: |
| data-only            |   13.10 µs |    13.22 µs |       +1% |
| named-event          |    7.00 µs |     7.28 µs |       +4% |
| identified-event     |   10.14 µs |    10.65 µs |       +5% |
| multibyte            |   10.56 µs |    10.79 µs |       +2% |
| heartbeat            |    7.44 µs |     7.36 µs |       −1% |
| idle-stream          |   20.66 µs |     7.95 µs |  **−62%** |
| small-chunk          |  143.78 µs |   114.69 µs |  **−22%** |
| large-multiline-data |   13.22 µs |    13.30 µs |       +1% |
| **huge-line-drip**   | **1.18 s** | **1.84 ms** | **~640×** |
| edge-cases           |    5.79 µs |     6.21 µs |       +7% |

Run-to-run variance on the same code across three identical invocations ranged from 1% (`edge-cases`) to **52%** (`data-only`) on this hardware, so sub-10% deltas on small fixtures aren't meaningful signals. The wins on `idle-stream`, `small-chunk`, and `huge-line-drip` are well outside that band.

### End-to-end (real workload)

1M rows / 280 MB payload via `mcp-clickhouse` → ClickHouse Cloud, fetched through `@ai-sdk/mcp`'s streamable-HTTP transport. Numbers came from a downstream MCP integration during an unrelated latency investigation:

| Version                   | Total time | RSS peak |
| ------------------------- | ---------: | -------: |
| 3.0.6                     |       93 s |   3.9 GB |
| 3.0.7 (the perf refactor) |      101 s |   2.3 GB |
| **3.0.7 + this fix**      |  **6.8 s** |   2.4 GB |

3.0.7 lowered RSS but didn't change wall time on this shape, which points to the per-feed concat being the dominant cost for streams where a single event spans many chunks.

Instrumented call distribution on the 280 MB payload: **4,436** `feed()` calls hit the new fast path (no concat, chunk had no terminator, just appended to the buffer); **2** hit the slow path (the first chunk carrying the `event:`/`data:` header, and the last chunk carrying the `\n\n` terminator). Exactly what the design predicted.