### PR TITLE
fix: detect implicit event boundary on consecutive JSON data: lines

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -156,6 +156,20 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
             lfIndex = chunk.indexOf('\n', searchIndex)
             continue
           }
+          // Heuristic: if accumulated data looks like a complete JSON value
+          // and the new `data:` line starts a new JSON structure, the server
+          // likely omitted the blank-line boundary between events. Dispatch
+          // the accumulated event and start fresh.
+          if (dataLines > 0 && isCompleteJsonValue(data, value)) {
+            onEvent({id, event: eventType, data})
+            id = undefined
+            data = value
+            dataLines = 1
+            eventType = undefined
+            searchIndex = lfIndex + 1
+            lfIndex = chunk.indexOf('\n', searchIndex)
+            continue
+          }
           // Multi-line data: concatenate with newline separator per spec.
           data = dataLines === 0 ? value : `${data}\n${value}`
           dataLines++
@@ -231,6 +245,13 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
       // 'data:'.length === 5, 'data: '.length === 6
       const valueStart = chunk.charCodeAt(start + 5) === SPACE ? start + 6 : start + 5
       const value = chunk.slice(valueStart, end)
+      // Same implicit-boundary heuristic as the fast path above.
+      if (dataLines > 0 && isCompleteJsonValue(data, value)) {
+        dispatchEvent()
+        data = value
+        dataLines = 1
+        return
+      }
       data = dataLines === 0 ? value : `${data}\n${value}`
       dataLines++
       return
@@ -372,6 +393,33 @@ function isDataPrefix(chunk: string, i: number, firstCharCode: number): boolean 
     chunk.charCodeAt(i + 2) === 116 &&
     chunk.charCodeAt(i + 3) === 97 &&
     chunk.charCodeAt(i + 4) === 58
+  )
+}
+
+/**
+ * Checks if buffered `data` looks like a structurally complete JSON value
+ * (`}` or `]` terminator) and `nextValue` starts a new JSON structure (`{`
+ * or `[`). When both hold, it is likely that the server sent consecutive SSE
+ * events separated by a single `\n` instead of the required blank line.
+ *
+ * Some LLM providers (e.g. GLM-4.7 via Baseten) emit `data: {...}\ndata: {...}`
+ * without the `\n\n` boundary between events, which the spec-compliant parser
+ * would concatenate into one malformed payload. This heuristic detects the
+ * implicit boundary so each JSON object becomes its own event.
+ *
+ * Plain-text multiline data (e.g. `data: YHOO\ndata: +2\ndata: 10`) does not
+ * trigger this heuristic because the partial lines do not end with `}` or `]`.
+ */
+function isCompleteJsonValue(data: string, nextValue: string): boolean {
+  if (data.length === 0 || nextValue.length === 0) return false
+  const trimmedEnd = data.trimEnd()
+  if (trimmedEnd.length === 0) return false
+  const lastChar = trimmedEnd.charCodeAt(trimmedEnd.length - 1)
+  const firstChar = nextValue.charCodeAt(0)
+  // } → {  or  ] → [
+  return (
+    (lastChar === 125 && firstChar === 123) ||
+    (lastChar === 93 && firstChar === 91)
   )
 }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -312,6 +312,27 @@ export async function getHugeMessageFixtureStream(onChunk: OnChunkCallback): Pro
   )
 }
 
+/**
+ * Simulates a non-compliant SSE server that omits the blank-line (`\n\n`)
+ * boundary between consecutive JSON events — e.g. some LLM providers when
+ * streaming tool calls:
+ *
+ *   data: {"index":0,"tool":"a"}
+ *   data: {"index":1,"tool":"b"}
+ *   \n
+ *
+ * The heuristic in `isCompleteJsonValue()` should split these into two
+ * separate events instead of concatenating them into one malformed payload.
+ */
+export async function getConsecutiveJsonFixtureStream(
+  onChunk: OnChunkCallback,
+): Promise<void> {
+  onChunk('data: {"index":0,"tool":"a"}\n')
+  onChunk('data: {"index":1,"tool":"b"}\n\n')
+  await delay()
+  onChunk(encode({event: 'done', data: '✔'}))
+}
+
 function delay(): Promise<void> {
   return new Promise((resolve) => nextTick(resolve))
 }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -7,6 +7,7 @@ import {
   getCarriageReturnFixtureStream,
   getCarriageReturnLineFeedFixtureStream,
   getCommentsFixtureStream,
+  getConsecutiveJsonFixtureStream,
   getDataFieldParsingFixtureStream,
   getEmptyEventsFixtureStream,
   getEmptyRetryFixtureStream,
@@ -483,6 +484,54 @@ test('passing a function to `createParser` will throw with helpful error', () =>
   }).toThrowError(
     '`callbacks` must be an object, got a function instead. Did you mean `{onEvent: fn}`?',
   )
+})
+
+test('consecutive JSON object `data:` lines without blank-line boundary are split into separate events', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  await getConsecutiveJsonFixtureStream(parser.feed)
+  mock.expectNextMessage({data: '{"index":0,"tool":"a"}', event: undefined})
+  mock.expectNextMessage({data: '{"index":1,"tool":"b"}', event: undefined})
+  mock.expectNextMessage({event: 'done', data: '✔'})
+})
+
+test('consecutive JSON `data:` lines in a single chunk produce separate events', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  parser.feed('data: {"a":1}\ndata: {"b":2}\n\n')
+  mock.expectNextMessage({data: '{"a":1}'})
+  mock.expectNextMessage({data: '{"b":2}'})
+})
+
+test('consecutive JSON array `data:` lines produce separate events', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  parser.feed('data: [1]\ndata: [2]\n\n')
+  mock.expectNextMessage({data: '[1]'})
+  mock.expectNextMessage({data: '[2]'})
+})
+
+test('plain-text multiline data is NOT split by the JSON heuristic', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  await getMultilineFixtureStream(parser.feed)
+  mock.expectNextMessage({data: 'YHOO\n+2\n10', event: 'stock'})
+  mock.expectNextMessage({data: 'GOOG\n-8\n1881', event: 'stock'})
+})
+
+test('event type carries over correctly with implicit boundary dispatch', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  parser.feed('event: tool_call\ndata: {"name":"get_weather"}\ndata: {"name":"get_time"}\n\n')
+  mock.expectNextMessage({data: '{"name":"get_weather"}', event: 'tool_call'})
+  mock.expectNextMessage({data: '{"name":"get_time"}', event: undefined})
+})
+
+test('JSON object followed by blank line still works normally', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser({onEvent: mock.onParse})
+  parser.feed('data: {"valid":true}\n\n')
+  mock.expectNextMessage({data: '{"valid":true}'})
 })
 
 async function sha256(message: string): Promise<string> {


### PR DESCRIPTION
Some SSE servers emit multiple `data:` lines separated by a single `\n` instead of the required blank line `\n\n` between events. This is technically a spec violation, but several LLM providers (observed with GLM-4.7, Kimi-K2.5) do this when streaming tool calls.

Currently the parser concatenates such lines into one event, producing malformed JSON like `{"a":1}\n{"b":2}` instead of two separate events.

This PR adds an `isCompleteJsonValue()` heuristic: when accumulated data ends with `}` or `]` and the next `data:` line starts with `{` or `[`, the accumulated event is dispatched and a new one begins. Plain-text multiline data (e.g. `data: YHOO\ndata: +2\ndata: 10`) is unaffected since the lines don't terminate JSON structures.

Changes:
- `isCompleteJsonValue()` helper — checks if buffered data looks structurally complete
- Applied in both `processLines()` fast path and `parseLine()` slow path
- 6 new tests covering broken-SSE, array values, multiline text, and event-type preservation
- All 54 existing tests pass
