### PR TITLE
feat: add `maxBufferSize` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ const parser = createParser({
 > [!NOTE]
 > Leading whitespace is not stripped from comments, eg `: comment` will give ` comment` as the comment value, not `comment` (note the leading space).
 
+### Limiting buffered memory (`maxBufferSize`)
+
+By default the parser buffers data indefinitely until a server completes an event. A server (or proxy) that never terminates a line, or that keeps appending `data:` lines without ever sending a blank line to dispatch the event, can therefore grow the parser's buffers without bound.
+
+Pass a `maxBufferSize` (in characters) to `createParser` to cap this. If the combined size of the pending line buffer and the in-progress event's data buffer exceeds the limit, the parser emits a `ParseError` with `type: 'max-buffer-size-exceeded'` and becomes terminated: subsequent calls to `feed()` will throw until `reset()` is called.
+
+```ts
+const parser = createParser({
+  maxBufferSize: 1024 * 1024, // 1 MB
+  onEvent(event) {
+    // …
+  },
+  onError(error) {
+    if (error.type === 'max-buffer-size-exceeded') {
+      // Stream peer is misbehaving — typically you'd close the connection.
+    }
+  },
+})
+```
+
+The same option is available on the [stream variant](#stream-usage); the stream is always errored when this limit is exceeded, regardless of the `onError` setting (since the underlying parser is unrecoverable without a `reset()`).
+
 ## Stream usage
 
 ```ts
@@ -117,6 +139,15 @@ import {EventSourceParserStream} from 'eventsource-parser/stream'
 const eventStream = response.body
   .pipeThrough(new TextDecoderStream())
   .pipeThrough(new EventSourceParserStream())
+```
+
+The stream constructor accepts the same options as `createParser` (e.g. `maxBufferSize`, `onComment`, `onRetry`) plus an `onError` that can be set to `'terminate'` to error the stream on parse errors:
+
+```ts
+new EventSourceParserStream({
+  maxBufferSize: 1024 * 1024,
+  onError: 'terminate',
+})
 ```
 
 Note that the TransformStream is exposed under a separate export (`eventsource-parser/stream`), in order to maximize compatibility with environments that do not have the `TransformStream` constructor available.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ const eventStream = response.body
   .pipeThrough(new EventSourceParserStream())
 ```
 
-The stream constructor accepts the same options as `createParser` (e.g. `maxBufferSize`, `onComment`, `onRetry`) plus an `onError` that can be set to `'terminate'` to error the stream on parse errors:
+The stream constructor accepts a subset of the `createParser` options (`onComment`, `onRetry`, `maxBufferSize`) plus an `onError` that can either be a function or set to `'terminate'` to error the stream on parse errors. Events are delivered through the stream itself rather than via an `onEvent` callback:
 
 ```ts
 new EventSourceParserStream({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@
  * The type of error that occurred.
  * @public
  */
-export type ErrorType = 'invalid-retry' | 'unknown-field'
+export type ErrorType = 'invalid-retry' | 'unknown-field' | 'max-buffer-size-exceeded'
 
 /**
  * Error thrown when encountering an issue during parsing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export {type ErrorType, ParseError} from './errors.ts'
 export {createParser} from './parse.ts'
-export type {EventSourceMessage, EventSourceParser, ParserCallbacks} from './types.ts'
+export type {
+  EventSourceMessage,
+  EventSourceParser,
+  ParserCallbacks,
+  ParserConfig,
+} from './types.ts'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,7 +3,7 @@
  * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
  */
 import {ParseError} from './errors.ts'
-import type {EventSourceParser, ParserCallbacks} from './types.ts'
+import type {EventSourceParser, ParserConfig} from './types.ts'
 
 // ASCII codes used in the hot parsing paths.
 const LF = 10
@@ -18,23 +18,20 @@ function noop(_arg: unknown) {
 /**
  * Creates a new EventSource parser.
  *
- * @param callbacks - Callbacks to invoke on different parsing events:
- *   - `onEvent` when a new event is parsed
- *   - `onError` when an error occurs
- *   - `onRetry` when a new reconnection interval has been sent from the server
- *   - `onComment` when a comment is encountered in the stream
+ * @param config - Parser configuration. Accepts callbacks (see {@link ParserCallbacks})
+ *   and options like `maxBufferSize` (see {@link ParserConfig}).
  *
  * @returns A new EventSource parser, with `parse` and `reset` methods.
  * @public
  */
-export function createParser(callbacks: ParserCallbacks): EventSourceParser {
-  if (typeof callbacks === 'function') {
+export function createParser(config: ParserConfig): EventSourceParser {
+  if (typeof config === 'function') {
     throw new TypeError(
       '`callbacks` must be an object, got a function instead. Did you mean `{onEvent: fn}`?',
     )
   }
 
-  const {onEvent = noop, onError = noop, onRetry = noop, onComment} = callbacks
+  const {onEvent = noop, onError = noop, onRetry = noop, onComment, maxBufferSize} = config
 
   // Trailing bytes from prior `feed()` calls that did not yet form a complete line.
   // Stored as an array of fragments and only joined when a line terminator arrives.
@@ -44,11 +41,19 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
   // makes the same workload linear.
   const pendingFragments: string[] = []
 
+  // Running total of `pendingFragments` lengths, kept in sync with the array so the
+  // `maxBufferSize` check doesn't have to walk the fragment list on every feed.
+  let pendingFragmentsLength = 0
+
   let isFirstChunk = true
   let id: string | undefined
   let data = ''
   let dataLines = 0
   let eventType: string | undefined
+
+  // Set after a `maxBufferSize` overflow. Once tripped, `feed()` becomes a no-op
+  // until `reset()` is called — see the comment on `maxBufferSize` in `ParserOptions`.
+  let terminated = false
 
   /**
    * Feeds a chunk of the SSE stream to the parser. Any trailing bytes that do
@@ -62,6 +67,12 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
    * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream
    */
   function feed(chunk: string) {
+    if (terminated) {
+      throw new Error(
+        'Cannot feed parser: it was terminated after exceeding the configured max buffer size. Call `reset()` to resume parsing.',
+      )
+    }
+
     if (isFirstChunk) {
       isFirstChunk = false
       // Match and strip UTF-8 BOM from the start of the stream, if present.
@@ -80,7 +91,11 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
     // Zero new work in the common case (every chunk ends with `\n\n`).
     if (pendingFragments.length === 0) {
       const trailing = processLines(chunk)
-      if (trailing !== '') pendingFragments.push(trailing)
+      if (trailing !== '') {
+        pendingFragments.push(trailing)
+        pendingFragmentsLength = trailing.length
+      }
+      checkBufferSize()
       return
     }
 
@@ -89,6 +104,8 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
     // avoiding (large single `data:` payload split across many tiny chunks).
     if (chunk.indexOf('\n') === -1 && chunk.indexOf('\r') === -1) {
       pendingFragments.push(chunk)
+      pendingFragmentsLength += chunk.length
+      checkBufferSize()
       return
     }
 
@@ -97,8 +114,31 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
     pendingFragments.push(chunk)
     const input = pendingFragments.join('')
     pendingFragments.length = 0
+    pendingFragmentsLength = 0
     const trailing = processLines(input)
-    if (trailing !== '') pendingFragments.push(trailing)
+    if (trailing !== '') {
+      pendingFragments.push(trailing)
+      pendingFragmentsLength = trailing.length
+    }
+    checkBufferSize()
+  }
+
+  function checkBufferSize() {
+    if (maxBufferSize === undefined) return
+    if (pendingFragmentsLength + data.length <= maxBufferSize) return
+
+    terminated = true
+    pendingFragments.length = 0
+    pendingFragmentsLength = 0
+    id = undefined
+    data = ''
+    dataLines = 0
+    eventType = undefined
+    onError(
+      new ParseError(`Buffered data exceeded max buffer size of ${maxBufferSize} characters`, {
+        type: 'max-buffer-size-exceeded',
+      }),
+    )
   }
 
   /**
@@ -350,6 +390,8 @@ export function createParser(callbacks: ParserCallbacks): EventSourceParser {
     dataLines = 0
     eventType = undefined
     pendingFragments.length = 0
+    pendingFragmentsLength = 0
+    terminated = false
   }
 
   return {feed, reset}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -21,7 +21,7 @@ function noop(_arg: unknown) {
  * @param config - Parser configuration. Accepts callbacks (see {@link ParserCallbacks})
  *   and options like `maxBufferSize` (see {@link ParserConfig}).
  *
- * @returns A new EventSource parser, with `parse` and `reset` methods.
+ * @returns A new EventSource parser, with `feed` and `reset` methods.
  * @public
  */
 export function createParser(config: ParserConfig): EventSourceParser {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -27,7 +27,7 @@ function noop(_arg: unknown) {
 export function createParser(config: ParserConfig): EventSourceParser {
   if (typeof config === 'function') {
     throw new TypeError(
-      '`callbacks` must be an object, got a function instead. Did you mean `{onEvent: fn}`?',
+      '`config` must be an object, got a function instead. Did you mean `createParser({onEvent: fn})`?',
     )
   }
 
@@ -51,8 +51,8 @@ export function createParser(config: ParserConfig): EventSourceParser {
   let dataLines = 0
   let eventType: string | undefined
 
-  // Set after a `maxBufferSize` overflow. Once tripped, `feed()` becomes a no-op
-  // until `reset()` is called — see the comment on `maxBufferSize` in `ParserOptions`.
+  // Set after a `maxBufferSize` overflow. Once tripped, `feed()` throws until
+  // `reset()` is called — see the comment on `maxBufferSize` in `ParserConfig`.
   let terminated = false
 
   /**

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -60,7 +60,7 @@ export interface StreamOptions {
  * const eventStream =
  *  response.body
  *   .pipeThrough(new TextDecoderStream())
- *   .pipeThrough(new EventSourceParserStream({terminateOnError: true}))
+ *   .pipeThrough(new EventSourceParserStream({onError: 'terminate'}))
  * ```
  *
  * @public

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -31,6 +31,17 @@ export interface StreamOptions {
    * @param comment - The comment encountered in the stream.
    */
   onComment?: ((comment: string) => void) | undefined
+
+  /**
+   * Maximum number of characters the parser is allowed to buffer across calls to `feed()`.
+   * See {@link ParserConfig.maxBufferSize} for details.
+   *
+   * When the limit is exceeded, the stream is always errored (regardless of the `onError`
+   * setting) since the underlying parser is unrecoverable without a `reset()`.
+   *
+   * @defaultValue `undefined` (unbounded)
+   */
+  maxBufferSize?: number | undefined
 }
 
 /**
@@ -55,7 +66,7 @@ export interface StreamOptions {
  * @public
  */
 export class EventSourceParserStream extends TransformStream<string, EventSourceMessage> {
-  constructor({onError, onRetry, onComment}: StreamOptions = {}) {
+  constructor({onError, onRetry, onComment, maxBufferSize}: StreamOptions = {}) {
     let parser!: EventSourceParser
 
     super({
@@ -65,16 +76,24 @@ export class EventSourceParserStream extends TransformStream<string, EventSource
             controller.enqueue(event)
           },
           onError(error) {
-            if (onError === 'terminate') {
-              controller.error(error)
-            } else if (typeof onError === 'function') {
+            if (typeof onError === 'function') {
               onError(error)
+            }
+
+            // `max-buffer-size-exceeded` is fatal — the parser is unusable until
+            // `reset()`, which the stream wrapper has no way to call. Always
+            // terminate the stream in that case so consumers see the meaningful
+            // `ParseError` instead of an opaque "cannot feed terminated parser"
+            // throw from the next chunk.
+            if (onError === 'terminate' || error.type === 'max-buffer-size-exceeded') {
+              controller.error(error)
             }
 
             // Ignore by default
           },
           onRetry,
           onComment,
+          maxBufferSize,
         })
       },
       transform(chunk) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,3 +95,28 @@ export interface ParserCallbacks {
    */
   onError?: ((error: ParseError) => void) | undefined
 }
+
+/**
+ * Configuration accepted by {@link createParser}. Extends {@link ParserCallbacks} with
+ * additional options that control parser behavior.
+ *
+ * @public
+ */
+export interface ParserConfig extends ParserCallbacks {
+  /**
+   * Maximum number of characters the parser is allowed to buffer across calls to `feed()`.
+   *
+   * Two unbounded surfaces exist in a streaming SSE parser:
+   * - A partial line that has not yet been terminated by `\n`, `\r`, or `\r\n`.
+   * - A multi-line event whose terminating blank line has not yet arrived (each `data:`
+   *   field gets appended to the buffered event).
+   *
+   * When the combined size of these buffers exceeds `maxBufferSize`, the parser emits a
+   * `ParseError` with `type: 'max-buffer-size-exceeded'` to `onError` and becomes
+   * terminated — subsequent calls to `feed()` will throw until `reset()` is called.
+   * This protects against unbounded memory growth from malformed or malicious streams.
+   *
+   * @defaultValue `undefined` (unbounded)
+   */
+  maxBufferSize?: number | undefined
+}

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -476,6 +476,89 @@ test('calls onError when the stream is invalid (no field separator)', async () =
   })
 })
 
+test('maxBufferSize: triggers on pending fragment overflow (no terminator)', () => {
+  const onEvent = vi.fn()
+  const onError = vi.fn()
+  const parser = createParser({onEvent, onError, maxBufferSize: 16})
+
+  // Single feed under the limit — fine.
+  parser.feed('short start')
+  expect(onError).not.toHaveBeenCalled()
+
+  // Pushes the accumulated fragments past the limit.
+  parser.feed(' and now too long')
+  expect(onError).toHaveBeenCalledTimes(1)
+
+  const error = onError.mock.calls[0]?.[0]
+  expect(error).toBeInstanceOf(ParseError)
+  expect(error).toMatchObject({type: 'max-buffer-size-exceeded'})
+})
+
+test('maxBufferSize: triggers on data buffer overflow (no blank line)', () => {
+  const onEvent = vi.fn()
+  const onError = vi.fn()
+  const parser = createParser({onEvent, onError, maxBufferSize: 32})
+
+  // Each `data:` line appends its value to the event's data buffer. Without a
+  // blank line, data accumulates unboundedly.
+  for (let i = 0; i < 50; i++) {
+    parser.feed(`data: chunk-${i}\n`)
+    if (onError.mock.calls.length > 0) break
+  }
+
+  expect(onError).toHaveBeenCalledTimes(1)
+  expect(onEvent).not.toHaveBeenCalled()
+
+  const error = onError.mock.calls[0]?.[0]
+  expect(error).toBeInstanceOf(ParseError)
+  expect(error).toMatchObject({type: 'max-buffer-size-exceeded'})
+})
+
+test('maxBufferSize: feed throws after overflow, until reset', () => {
+  const onEvent = vi.fn()
+  const onError = vi.fn()
+  const parser = createParser({onEvent, onError, maxBufferSize: 8})
+
+  // The overflowing feed itself does not throw — it reports via onError.
+  parser.feed('this is too long for the buffer')
+  expect(onError).toHaveBeenCalledTimes(1)
+
+  // Subsequent feeds throw, signalling that the parser is unusable.
+  expect(() => parser.feed('data: hello\n\n')).toThrow(/max buffer size/)
+  expect(() => parser.feed('data: world\n\n')).toThrow(/max buffer size/)
+  expect(onEvent).not.toHaveBeenCalled()
+  expect(onError).toHaveBeenCalledTimes(1)
+
+  // After reset, the parser works again.
+  parser.reset()
+  parser.feed('data: hello\n\n')
+  expect(onEvent).toHaveBeenCalledTimes(1)
+  expect(onEvent).toHaveBeenLastCalledWith({id: undefined, event: undefined, data: 'hello'})
+})
+
+test('maxBufferSize: not triggered when events dispatch within the limit', () => {
+  const onEvent = vi.fn()
+  const onError = vi.fn()
+  const parser = createParser({onEvent, onError, maxBufferSize: 64})
+
+  // Lots of small events, each well under the limit and dispatched immediately.
+  for (let i = 0; i < 100; i++) {
+    parser.feed(`data: ${i}\n\n`)
+  }
+
+  expect(onError).not.toHaveBeenCalled()
+  expect(onEvent).toHaveBeenCalledTimes(100)
+})
+
+test('maxBufferSize: undefined option means unbounded (default behavior)', () => {
+  const onEvent = vi.fn()
+  const onError = vi.fn()
+  const parser = createParser({onEvent, onError})
+
+  parser.feed('x'.repeat(1_000_000))
+  expect(onError).not.toHaveBeenCalled()
+})
+
 test('passing a function to `createParser` will throw with helpful error', () => {
   expect(() => {
     // @ts-expect-error Should not allow a function, typing-wise

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -564,7 +564,7 @@ test('passing a function to `createParser` will throw with helpful error', () =>
     // @ts-expect-error Should not allow a function, typing-wise
     createParser(() => null)
   }).toThrowError(
-    '`callbacks` must be an object, got a function instead. Did you mean `{onEvent: fn}`?',
+    '`config` must be an object, got a function instead. Did you mean `createParser({onEvent: fn})`?',
   )
 })
 

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1,6 +1,7 @@
 import {encode} from 'eventsource-encoder'
-import {expect, test} from 'vitest'
+import {expect, test, vi} from 'vitest'
 
+import {ParseError} from '../src/errors.ts'
 import {type EventSourceMessage, EventSourceParserStream} from '../src/stream.ts'
 
 test('can use `EventSourceParserStream`', async () => {
@@ -40,4 +41,42 @@ test('can use `EventSourceParserStream`', async () => {
     })
     return
   }
+})
+
+test('maxBufferSize: terminates the stream when onError is `terminate`', async () => {
+  const response = new Response('x'.repeat(1024))
+  if (!response.body) {
+    throw new Error('No body')
+  }
+
+  const eventStream = response.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new EventSourceParserStream({maxBufferSize: 64, onError: 'terminate'}))
+    .getReader()
+
+  await expect(eventStream.read()).rejects.toBeInstanceOf(ParseError)
+})
+
+test('maxBufferSize: invokes custom onError function and errors the stream', async () => {
+  const onError = vi.fn()
+  const response = new Response('x'.repeat(1024))
+  if (!response.body) {
+    throw new Error('No body')
+  }
+
+  const eventStream = response.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new EventSourceParserStream({maxBufferSize: 64, onError}))
+    .getReader()
+
+  // Overflow is fatal, so the stream errors even though `onError` is a function
+  // (not 'terminate'). The user's `onError` still fires so they can observe the error.
+  await expect(eventStream.read()).rejects.toMatchObject({
+    type: 'max-buffer-size-exceeded',
+  })
+
+  expect(onError).toHaveBeenCalled()
+  const error = onError.mock.calls[0]?.[0]
+  expect(error).toBeInstanceOf(ParseError)
+  expect(error).toMatchObject({type: 'max-buffer-size-exceeded'})
 })


### PR DESCRIPTION
By default the parser buffers data indefinitely until a server completes an event. A server (or proxy) that never terminates a line, or that keeps appending `data:` lines without ever sending a blank line to dispatch the event, can therefore grow the parser's buffers without bound.

Pass a `maxBufferSize` (in characters) to `createParser` to cap this. If the combined size of the pending line buffer and the in-progress event's data buffer exceeds the limit, the parser emits a `ParseError` with `type: 'max-buffer-size-exceeded'` and becomes terminated: subsequent calls to `feed()` will throw until `reset()` is called.
