### PR TITLE
fix: `id:` line containing a NULL character wiping the buffered event id

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -291,7 +291,9 @@ export function createParser(config: ParserConfig): EventSourceParser {
     ) {
       // 'id:'.length === 3, 'id: '.length === 4
       const value = chunk.slice(chunk.charCodeAt(start + 3) === SPACE ? start + 4 : start + 3, end)
-      id = value.includes('\0') ? undefined : value
+      // If the field value does not contain U+0000 NULL, then set the `ID` buffer to
+      // the field value. Otherwise, ignore the field.
+      if (!value.includes('\0')) id = value
       return
     }
 
@@ -333,7 +335,7 @@ export function createParser(config: ParserConfig): EventSourceParser {
       case 'id':
         // If the field value does not contain U+0000 NULL, then set the `ID` buffer to
         // the field value. Otherwise, ignore the field.
-        id = value.includes('\0') ? undefined : value
+        if (!value.includes('\0')) id = value
         break
       case 'retry':
         // If the field value consists of only ASCII digits, then interpret the field value as an

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -311,6 +311,20 @@ test('stream with partially incorrect retry fields', async () => {
   mock.expectNumberOfMessagesToBe(1)
 })
 
+test('stream with `id` field containing a NULL character', async () => {
+  const mock = getParseResultMock()
+  const parser = createParser(mock.callbacks)
+
+  // Spec says of the `id` field:
+  // > If the field value does not contain U+0000 NULL, then set the last event ID buffer
+  // > to the field value. Otherwise, ignore the field.
+  // Ignoring the field means the previously buffered `123` must survive.
+  parser.feed('id: 123\nid: bad\0id\ndata: hello\n\n')
+
+  mock.expectNumberOfMessagesToBe(1)
+  mock.expectNextMessage({id: '123', event: undefined, data: 'hello'})
+})
+
 test('stream with incorrect retry fields', async () => {
   const mock = getParseResultMock()
   const parser = createParser(mock.callbacks)


### PR DESCRIPTION
## What

Both `id:` implementations assign `undefined` when the field value contains U+0000 NULL (`src/parse.ts:294` fast path and `:336` `case 'id'`). Per the SSE spec, a field with NULL must be **ignored** — so an `id` line with NULL currently clears an id that was already buffered:

```
id: 123
id: bad\0id     ← spec: ignore this line; today it resets the buffer to undefined
data: hello
```

The event should dispatch with `id: '123'`; on `main` it dispatches with `id: undefined`. Same shape as #26 for `retry`, applied to `id`.

## Fix

Guard instead of nulling, in both places:

```ts
if (!value.includes('\0')) id = value
```

Scope, honestly: this changes only the NULL handling. The parser's existing per-dispatch reset of the id buffer (`parse.ts:133,170,192,375,388`) is a separate behavior — the spec's buffer does not get reset on dispatch ("The buffer does not get reset") — and this PR deliberately does not touch it.

## Test

New regression test in `test/parse.test.ts` (following the existing `getParseResultMock` pattern and quoting the spec): feeds `id: 123\nid: bad\0id\ndata: hello\n\n` and expects `{id: '123', event: undefined, data: 'hello'}`.

- Without the fix: fails (`Received: undefined` at the id assertion).
- With the fix: passes; revert/re-apply cycle re-confirmed.
- Full suite: **50/50** ✅ · `oxlint`: 0 errors ✅ · `tsc --noEmit` ✅ · `oxfmt` ✅

Note on #33: I saw the `parse.ts` rewrite in flight there (the same ternaries live at :404/:446 of its head) — happy to rebase the two-line guard onto it if it lands first, or leave it to you to fold in.

Node v24.14.1 on Windows; no Deno/Bun here, so only the Node suite was run (the change is runtime-agnostic). AI-assisted: drafted with AI assistance and verified locally as above.