### PR TITLE
ci: generate changesets from conventional commit PR titles

### DIFF
--- a/.github/scripts/generate-changeset.mjs
+++ b/.github/scripts/generate-changeset.mjs
@@ -1,0 +1,163 @@
+/**
+ * Derives a changeset from the conventional commit in a pull request title.
+ *
+ * Pull requests are squash merged with the title as the commit message, so the
+ * title is the canonical description of the change. This keeps `.changeset/pr-<n>.md`
+ * in sync with it: written when the title warrants a release, removed when it no
+ * longer does, and left alone the moment a human takes ownership of the changeset.
+ *
+ * Runs from the base branch under `pull_request_target`, so it never executes or
+ * imports anything from the pull request itself.
+ */
+import {randomUUID} from 'node:crypto'
+import {appendFileSync} from 'node:fs'
+
+const {
+  GH_TOKEN,
+  GITHUB_OUTPUT,
+  GITHUB_REPOSITORY,
+  PACKAGE_NAME,
+  PR_BODY = '',
+  PR_HEAD_SHA,
+  PR_NUMBER,
+  PR_REPO,
+  PR_TITLE,
+} = process.env
+
+const required = {
+  GH_TOKEN,
+  GITHUB_OUTPUT,
+  GITHUB_REPOSITORY,
+  PACKAGE_NAME,
+  PR_HEAD_SHA,
+  PR_NUMBER,
+  PR_REPO,
+  PR_TITLE,
+}
+const missing = Object.keys(required).filter((key) => !required[key])
+if (missing.length > 0) {
+  throw new Error(`Missing required environment variables: ${missing.join(', ')}`)
+}
+
+const CHANGESET_FILE = `.changeset/pr-${PR_NUMBER}.md`
+
+/**
+ * Marks the file as owned by this script. Delete the line to take it over by
+ * hand - the next run will see the marker is gone and stop touching the file.
+ */
+const AUTO_GENERATED_MARKER = '<!-- auto-generated -->'
+
+/** @param {string} path */
+async function ghApi(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {Accept: 'application/vnd.github+json', Authorization: `Bearer ${GH_TOKEN}`},
+  })
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** @param {string} key @param {string} value */
+function setOutput(key, value) {
+  appendFileSync(GITHUB_OUTPUT, `${key}=${value}\n`)
+}
+
+/** @param {string} title */
+function parseConventionalCommit(title) {
+  const match = title.match(/^([a-z]+)(\((.+)\))?(!)?:\s.+/)
+  return match ? {breaking: match[4] === '!', type: match[1]} : null
+}
+
+/** @param {string} type @param {boolean} breaking @param {string} body */
+function determineBump(type, breaking, body) {
+  if (breaking) return 'major'
+  if (body.split('\n').some((line) => line.startsWith('BREAKING CHANGE:'))) return 'major'
+  if (type === 'feat') return 'minor'
+  if (['fix', 'perf', 'revert'].includes(type)) return 'patch'
+  return null
+}
+
+/** Every changed file path in the pull request, following pagination. */
+async function getChangedFiles() {
+  const files = []
+  for (let page = 1; ; page++) {
+    const data = await ghApi(
+      `/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}`,
+    )
+    if (data.length === 0) return files
+    files.push(...data.map((file) => file.filename))
+  }
+}
+
+/** Contents of the auto-generated changeset on the pull request branch, if it exists. */
+async function getExistingChangeset() {
+  const url = `https://api.github.com/repos/${PR_REPO}/contents/${CHANGESET_FILE}?ref=${PR_HEAD_SHA}`
+  const res = await fetch(url, {
+    headers: {Accept: 'application/vnd.github+json', Authorization: `Bearer ${GH_TOKEN}`},
+  })
+  if (res.status === 404) return null
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${await res.text()}`)
+  }
+  const data = await res.json()
+  return Buffer.from(data.content, 'base64').toString()
+}
+
+/**
+ * Nothing to release. Clean up after ourselves if we wrote a changeset for an
+ * earlier version of the title, otherwise there is nothing to do.
+ * @param {string | null} existingChangeset
+ */
+function skipOrRemove(existingChangeset) {
+  if (existingChangeset === null) {
+    setOutput('action', 'skip')
+    return
+  }
+  setOutput('action', 'remove')
+  setOutput('changeset_file', CHANGESET_FILE)
+}
+
+const changedFiles = await getChangedFiles()
+const existingChangeset = await getExistingChangeset()
+
+if (existingChangeset === null) {
+  const manual = changedFiles.filter(
+    (file) =>
+      file.startsWith('.changeset/') && file.endsWith('.md') && file !== '.changeset/README.md',
+  )
+  if (manual.length > 0) {
+    console.log(`Skipping, the pull request already has a changeset: ${manual.join(', ')}`)
+    setOutput('action', 'skip')
+    process.exit(0)
+  }
+} else if (!existingChangeset.startsWith(AUTO_GENERATED_MARKER)) {
+  console.log('Skipping, the changeset was edited by hand (marker removed)')
+  setOutput('action', 'skip')
+  process.exit(0)
+}
+
+const parsed = parseConventionalCommit(PR_TITLE)
+if (parsed === null) {
+  console.log(`::warning::Pull request title is not a conventional commit: ${PR_TITLE}`)
+  skipOrRemove(existingChangeset)
+  process.exit(0)
+}
+
+const bump = determineBump(parsed.type, parsed.breaking, PR_BODY)
+if (bump === null) {
+  console.log(`\`${parsed.type}\` does not release a new version, no changeset needed`)
+  skipOrRemove(existingChangeset)
+  process.exit(0)
+}
+
+// Keep the full conventional commit title - it is what lands in the changelog
+const content = `${AUTO_GENERATED_MARKER}\n---\n'${PACKAGE_NAME}': ${bump}\n---\n\n${PR_TITLE}\n`
+
+console.log(`Generated changeset:\n${content}`)
+
+setOutput('action', 'write')
+setOutput('changeset_file', CHANGESET_FILE)
+// Random delimiter so a crafted pull request title cannot inject extra outputs
+const delimiter = `CHANGESET_EOF_${randomUUID().replaceAll('-', '')}`
+appendFileSync(GITHUB_OUTPUT, `changeset_content<<${delimiter}\n${content}${delimiter}\n`)

--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -1,0 +1,106 @@
+name: Generate changeset
+
+# Pull requests are squash merged with the title as the commit message, so the
+# conventional commit in the title says everything a changeset needs to know.
+# Derive one from it instead of asking every contributor to write it by hand.
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  generate-changeset:
+    name: Generate changeset
+    runs-on: ubuntu-latest
+    # Dependency bots are covered by dependency-changesets.yml, and `no changeset`
+    # is the escape hatch for changes that shouldn't be released on their own.
+    #
+    # Pull requests from forks are skipped: GITHUB_TOKEN cannot push to a fork's
+    # branch. Swap in a GitHub App token (see actions/create-github-app-token) if
+    # they should be covered too.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'no changeset')
+    permissions:
+      contents: write # push the changeset commit to the pull request branch
+      pull-requests: read # list the files the pull request changes
+    steps:
+      # Checked out from the base branch, never from the pull request, so a pull
+      # request cannot rewrite the script that runs with a write-scoped token
+      - name: Check out the base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          sparse-checkout: |
+            .github/scripts
+            package.json
+          sparse-checkout-cone-mode: false
+          path: base
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Work out what the changeset should be
+        id: analyze
+        working-directory: base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PACKAGE_NAME="$(node -p 'require("./package.json").name')" \
+            node .github/scripts/generate-changeset.mjs
+
+      - name: Check out the pull request branch
+        if: steps.analyze.outputs.action != 'skip'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Commit and push the changeset
+        if: steps.analyze.outputs.action != 'skip'
+        env:
+          ACTION: ${{ steps.analyze.outputs.action }}
+          CHANGESET_CONTENT: ${{ steps.analyze.outputs.changeset_content }}
+          CHANGESET_FILE: ${{ steps.analyze.outputs.changeset_file }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$ACTION" = 'write' ]; then
+            printf '%s' "$CHANGESET_CONTENT" > "$CHANGESET_FILE"
+            message="chore: update changeset for #${PR_NUMBER}"
+          elif [ -f "$CHANGESET_FILE" ]; then
+            rm "$CHANGESET_FILE"
+            message="chore: remove changeset for #${PR_NUMBER}"
+          else
+            echo 'Nothing to remove'
+            exit 0
+          fi
+
+          git add --all "$CHANGESET_FILE"
+          if git diff --cached --quiet; then
+            echo 'Changeset is already up to date'
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit --message "$message"
+          # Bail out rather than clobber anything pushed since the run started
+          git push --force-with-lease="${PR_HEAD_REF}:${PR_HEAD_SHA}" origin "HEAD:${PR_HEAD_REF}"


### PR DESCRIPTION
Derives a changeset from the conventional commit in a pull request title, so
contributors do not have to remember `npx changeset` for every change.

Adapted from [`sanity-io/cli`](https://github.com/sanity-io/cli/blob/main/.github/workflows/generate-changeset.yml),
with a few differences for this repo:

- Single package, so the workspace package discovery is replaced by reading `name` from `package.json` on the base branch.
- Plain `GITHUB_TOKEN` instead of a GitHub App token, so pull requests from forks are skipped. `GITHUB_TOKEN` cannot push to a fork's branch. Dropping in `actions/create-github-app-token` later is enough to cover them.
- Dependency bots are excluded, since `dependency-changesets.yml` already handles those. Without the exclusion both workflows would race to push to the same branch.

### How it behaves

The changeset stays in sync with the title rather than being written once:

- `feat` maps to minor, `fix`/`perf`/`revert` to patch, and a `!` or a `BREAKING CHANGE:` footer to major. Everything else releases nothing.
- Retitling `feat:` to `chore:` removes the generated changeset again.
- A `<!-- auto-generated -->` marker on the first line records that the file is owned by the workflow. Delete the line and the workflow stops touching the file.
- A hand written changeset anywhere in `.changeset/` wins, and the workflow does nothing.
- The `no changeset` label is an escape hatch.

The script is checked out from the base branch, never from the pull request, so
a pull request cannot rewrite the code that runs with a write scoped token under
`pull_request_target`.

### Note on the `mscharley/dependency-changesets-action` route

Reusing the existing action for all pull requests does not work. It derives the
affected packages from the `package.json` files in the diff, so a `feat:` pull
request that does not touch `package.json` produces no changeset, and it bails
on any pull request with more than one commit.

### Verification

- 21 cases against the script with a stubbed GitHub API: every bump type, scope with and without `!`, non-conventional and uppercase titles, a manual changeset being present, the human-took-over marker, remove-on-retitle and rewrite-on-retitle.
- Generated output round-trips through `@changesets/parse`, including the leading marker comment.
- A title containing a newline cannot inject extra `GITHUB_OUTPUT` keys.
- `actionlint` clean on all workflows, `oxfmt` and `oxlint` clean on the script.

The `no changeset` label does not exist in the repo yet. It is harmless if
absent, but it needs creating before it can be used.
