### PR TITLE
ci: use a conventional commit subject for the version pull request

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -17,14 +17,16 @@ jobs:
   generate-changeset:
     name: Generate changeset
     runs-on: ubuntu-latest
-    # Dependency bots are covered by dependency-changesets.yml, and `no changeset`
-    # is the escape hatch for changes that shouldn't be released on their own.
+    # The version pull request consumes changesets rather than adding them, dependency
+    # bots are covered by dependency-changesets.yml, and `no changeset` is the escape
+    # hatch for changes that shouldn't be released on their own.
     #
     # Pull requests from forks are skipped: GITHUB_TOKEN cannot push to a fork's
     # branch. Swap in a GitHub App token (see actions/create-github-app-token) if
     # they should be covered too.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'changeset-release/') &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'renovate[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'dependencies') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
           version: npm run release:version
           publish: npm run release:publish
           createGithubReleases: true
+          # Conventional commit subjects, so the version pull request and the
+          # commit it squashes into main match every other commit in the history
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
         env:
           # Used to open the version PR, create GitHub releases and resolve
           # contributors/PR links in the changelog


### PR DESCRIPTION
The changesets action defaults both the version pull request title and its
commit message to `Version Packages`, which is the only non-conventional subject
in the history. Set both to `chore: version packages`.

`title` and `commit` are the `changesets/action@v1` input names. The inputs were
renamed to `pr-title` and `commit-message` on `main`, so these need updating
alongside any future bump off `v1`.

The action retitles an existing version pull request on every run, not just on
creation, so #36 gets picked up the next time the release workflow runs rather
than needing to be recreated.

Also excludes `changeset-release/*` from the changeset generator added in #37.
That pull request consumes changesets rather than adding them, so it should
never be a candidate. It already skipped on the `chore:` prefix, but only by
coincidence of the type mapping.